### PR TITLE
fix: broken alchemy providers

### DIFF
--- a/context/Web3Context.ts
+++ b/context/Web3Context.ts
@@ -36,8 +36,8 @@ export const NETWORKS: { [key: string]: string } = {
 
 export interface Web3ContextType {
   alchemyEnhancedApiProvider: AlchemyEnhancedApiProvider
-  alchemyWsProvider: WebSocketProvider
-  infuraWsProvider?: WebSocketProvider
+  ethMainnetProvider: WebSocketProvider
+  alchemyWsProvider?: WebSocketProvider
   walletConnectProvider?: W3Provider
   metamaskProvider?: W3Provider
   coinbaseProvider?: W3Provider

--- a/providers/AccountProvider.tsx
+++ b/providers/AccountProvider.tsx
@@ -15,7 +15,7 @@ import useWeb3 from '@/hooks/use-web3'
 
 const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const {
-    alchemyWsProvider,
+    ethMainnetProvider,
     metamaskProvider,
     coinbaseProvider,
     walletConnectProvider,
@@ -85,7 +85,11 @@ const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
         return
       }
 
-      const newAccount = new Account(addresses[0], newSigner, alchemyWsProvider)
+      const newAccount = new Account(
+        addresses[0],
+        newSigner,
+        ethMainnetProvider
+      )
 
       setAccount(newAccount)
       setProvider(newProvider)
@@ -95,12 +99,13 @@ const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
       walletConnectProvider,
       metamaskProvider,
       coinbaseProvider,
-      alchemyWsProvider,
+      ethMainnetProvider,
     ]
   )
 
   const initState = useCallback(
     async (newProvider: W3Provider) => {
+      console.log('init state')
       const [error, accounts] = await resolver(
         (newProvider.provider as EthProvider).request({
           method: 'eth_accounts',
@@ -122,7 +127,7 @@ const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
         const newAccount = new Account(
           addresses[0],
           newProvider.getSigner(),
-          alchemyWsProvider
+          ethMainnetProvider
         )
 
         setAccount(newAccount)
@@ -130,7 +135,7 @@ const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
         setSigner(newProvider.getSigner())
       }
     },
-    [alchemyWsProvider]
+    [ethMainnetProvider]
   )
 
   useEffect(() => {
@@ -152,7 +157,7 @@ const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
           const newAccount = new Account(
             accounts[0],
             new ethers.providers.Web3Provider(provider).getSigner(),
-            alchemyWsProvider
+            ethMainnetProvider
           )
           setAccount(newAccount)
         } else {
@@ -178,7 +183,7 @@ const AccountProvider: FC<{ children: ReactNode }> = ({ children }) => {
         provider.removeListener('chainChanged', updateChain)
       }
     }
-  }, [provider, network, signOut, alchemyWsProvider])
+  }, [provider, network, signOut, ethMainnetProvider])
 
   return (
     <AccountContext.Provider

--- a/providers/Web3Provider.tsx
+++ b/providers/Web3Provider.tsx
@@ -81,17 +81,17 @@ const Web3Provider: FC<{ children: ReactNode }> = ({ children }) => {
     initAlchemyEnhancedApiProvider(NETWORKS[process.env.ENV || 'production'])
   )
   // Use this for reading from the archive nodes
-  const [alchemyWsProvider] = useState(
-    ethers.providers.AlchemyProvider.getWebSocketProvider(
-      1,
-      process.env.ALCHEMY_ID
-    )
-  )
-  // Use this for contract interaction
-  const [infuraWsProvider, setInfuraWsProvider] = useState<
+  const [alchemyWsProvider, setAlchemyWsProvider] = useState<
     WebSocketProvider | undefined
   >()
-  // Use this or injected providers to sign and send transactions
+  // Use this for reading from the archive nodes on Ethereum Mainnet
+  const [ethMainnetProvider] = useState(
+    ethers.providers.AlchemyProvider.getWebSocketProvider(
+      1,
+      process.env.ETHEREUM_ALCHEMY_API
+    )
+  )
+  // Use this for injected providers to sign and send transactions
   const [walletConnectProvider, setWalletConnectProvider] = useState<
     W3Provider | undefined
   >()
@@ -190,20 +190,20 @@ const Web3Provider: FC<{ children: ReactNode }> = ({ children }) => {
 
       setNetwork(net)
     } else {
-      setInfuraWsProvider(
-        ethers.providers.InfuraProvider.getWebSocketProvider(
+      setWalletConnectProvider(initWalletConnectProvider(network))
+      setAlchemyWsProvider(
+        ethers.providers.AlchemyProvider.getWebSocketProvider(
           network,
-          process.env.INFURA_ID
+          apiKeyForNetwork(NETWORKS[process.env.ENV || 'production'])
         )
       )
-      setWalletConnectProvider(initWalletConnectProvider(network))
     }
   }, [network])
 
   const ctx = {
     alchemyEnhancedApiProvider,
     alchemyWsProvider,
-    infuraWsProvider,
+    ethMainnetProvider,
     walletConnectProvider,
     metamaskProvider,
     coinbaseProvider,


### PR DESCRIPTION
## Purpose

Fixes the error `Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.7.1)`

The Alchemy env var was incorrect for Ethereum Mainnet.

## Screenshots

## Testing Instructions

## Checklist

- [ ] Title follows the [naming convention](../README.md#pull-requests).
- [ ] Add a description.
- [ ] Add screenshots (optional).
- [ ] Add testing instructions.
- [ ] Add at least one reviewer.
- [ ] Apply related labels (optional).
- [ ] Leave comments on changes you would like to discuss.
- [ ] Remove changes that are not related to this pull request.
- [ ] Remove debugging code.
- [ ] Test your changes locally and on staging (if applicable).
- [ ] Ensure test coverage value in config matches actual coverage (if applicable).
- [ ] Ensure the build is passing.
